### PR TITLE
Utilize map_join/3 in redis helper test support

### DIFF
--- a/test/support/redis_helper.ex
+++ b/test/support/redis_helper.ex
@@ -1,6 +1,6 @@
 defmodule RedisHelper do
   def xadd(pid, stream, id, list) do
-    value = Enum.map(list, fn {k, v} -> "#{k} #{inspect(v)}" end) |> Enum.join(" ")
+    value = Enum.map_join(list, " ", fn {k, v} -> "#{k} #{inspect(v)}" end)
     Redix.command!(pid, ~w(XADD #{stream} #{id} #{value}))
   end
 


### PR DESCRIPTION
Rather than mapping, then joining, we can do it in 1 iteration