### PR TITLE
feat: Allow MKSTREAM to be set when creating consumer group

### DIFF
--- a/lib/redix_client.ex
+++ b/lib/redix_client.ex
@@ -41,8 +41,15 @@ defmodule OffBroadwayRedisStream.RedixClient do
 
   @impl true
   def create_group(id, config) do
-    %{stream: stream, group: group, redix_pid: pid} = config
+    %{stream: stream, group: group, redix_pid: pid, make_stream: make_stream} = config
     cmd = ~w(XGROUP CREATE #{stream} #{group} #{id})
+
+    cmd =
+      if(make_stream) do
+        cmd ++ ["MKSTREAM"]
+      else
+        cmd
+      end
 
     case command(pid, cmd) do
       {:ok, _} -> :ok

--- a/lib/redix_client.ex
+++ b/lib/redix_client.ex
@@ -45,7 +45,7 @@ defmodule OffBroadwayRedisStream.RedixClient do
     cmd = ~w(XGROUP CREATE #{stream} #{group} #{id})
 
     cmd =
-      if(make_stream) do
+      if make_stream do
         cmd ++ ["MKSTREAM"]
       else
         cmd


### PR DESCRIPTION
This is useful for when I haven't added any entries to a stream yet and `off_broadway_redis_stream` starts polling for messages 