### PR TITLE
feat: Add flag to XDEL messages when XACKing them

### DIFF
--- a/lib/redis_client.ex
+++ b/lib/redis_client.ex
@@ -37,6 +37,9 @@ defmodule OffBroadwayRedisStream.RedisClient do
   @callback ack(ids :: [id], config :: keyword) ::
               :ok | {:error, ConnectionError.t()} | {:error, any}
 
+  @callback delete_message(ids :: [id], config :: keyword) ::
+              :ok | {:error, ConnectionError.t()} | {:error, any}
+
   @callback delete_consumers(consumers :: [String.t()], config :: keyword) ::
               :ok | {:error, ConnectionError.t()} | {:error, any}
 end

--- a/lib/redix_client.ex
+++ b/lib/redix_client.ex
@@ -90,6 +90,19 @@ defmodule OffBroadwayRedisStream.RedixClient do
   end
 
   @impl true
+  def delete_message([], _config), do: :ok
+
+  def delete_message(ids, config) do
+    %{stream: stream, redix_pid: pid} = config
+    cmd = ["XDEL", stream] ++ ids
+
+    case Redix.noreply_command(pid, cmd) do
+      :ok -> :ok
+      result -> result
+    end
+  end
+
+  @impl true
   def delete_consumers(consumers, config) do
     %{stream: stream, group: group, redix_pid: pid} = config
     commands = Enum.map(consumers, &["XGROUP", "DELCONSUMER", stream, group, &1])

--- a/test/support/redis_helper.ex
+++ b/test/support/redis_helper.ex
@@ -12,6 +12,10 @@ defmodule RedisHelper do
     Redix.command!(pid, ~w(XPENDING #{stream} #{group} - + 100000 #{consumer}))
   end
 
+  def xlen(pid, stream) do
+    Redix.command!(pid, ~w(XLEN #{stream}))
+  end
+
   def flushall(pid) do
     Redix.command!(pid, ~w(FLUSHALL))
   end

--- a/test/support/redis_mock.ex
+++ b/test/support/redis_mock.ex
@@ -21,6 +21,14 @@ defmodule OffBroadwayRedisStream.RedisMock do
   end
 
   @impl true
+  def delete_message(ids, config) do
+    info = %{ids: ids, pid: self()}
+    Super.delete_message(ids, config)
+    send(config[:test_pid], {:delete_message, info})
+    :ok
+  end
+
+  @impl true
   def consumers_info(config) do
     {:ok, info} = Super.consumers_info(config)
     send(config[:test_pid], {:consumer_info, info})


### PR DESCRIPTION
Hello! 

This Pull Request adds the ability to [delete messages](https://redis.io/commands/xdel) immediately after they are acknowledged. This can be configured using the optional `delete_on_acknowledgment` flag when starting the producer.