### PR TITLE
offload Redis commands until after initilization to prevent crashing

### DIFF
--- a/lib/heartbeat.ex
+++ b/lib/heartbeat.ex
@@ -6,6 +6,10 @@ defmodule OffBroadwayRedisStream.Heartbeat do
 
   @max_id round(:math.pow(2, 64)) - 1
 
+  def start_link(opts) do
+    start_link(opts[:client], opts[:config], opts[:heartbeat_interval])
+  end
+
   def start_link(client, config, heartbeat_interval) do
     GenServer.start_link(__MODULE__, {client, config, heartbeat_interval})
   end
@@ -22,6 +26,7 @@ defmodule OffBroadwayRedisStream.Heartbeat do
 
   @impl true
   def handle_continue(nil, state) do
+    create_group(state)
     heartbeat(state)
     {:noreply, state}
   end
@@ -34,6 +39,25 @@ defmodule OffBroadwayRedisStream.Heartbeat do
 
   @redis_command_retry_timeout 300
   @max_retries 2
+
+  defp create_group(%{client: client, config: config} = state, retry_count \\ 0) do
+    # we need to ensure the group is created before a heartbeat will succeed
+    case client.create_group(config[:group_start_id], config) do
+      :ok ->
+        :ok
+
+      {:error, %RedisClient.ConnectionError{} = error} when retry_count < @max_retries ->
+        Logger.warn(
+          "Failed to create group, retry_count: #{retry_count}, reason: #{inspect(error.reason)}"
+        )
+
+        Process.sleep(@redis_command_retry_timeout * (retry_count + 1))
+        create_group(state, retry_count + 1)
+
+      {:error, error} ->
+        raise "Create group failed, " <> inspect(error)
+    end
+  end
 
   defp heartbeat(
          %{client: client, config: config, heartbeat_interval: interval} = state,

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -107,8 +107,6 @@ defmodule OffBroadwayRedisStream.Producer do
         raise ArgumentError, "invalid options given to #{inspect(client)}.init/1, " <> message
 
       {:ok, redis_config} ->
-        init_consumer_group!(client, opts[:group_start_id], redis_config)
-
         {:ok, heartbeat_pid} =
           Heartbeat.start_link(client, redis_config, opts[:heartbeat_interval])
 
@@ -475,10 +473,6 @@ defmodule OffBroadwayRedisStream.Producer do
       result ->
         result
     end
-  end
-
-  defp init_consumer_group!(client, group_start_id, redis_config) do
-    :ok = client.create_group(group_start_id, redis_config)
   end
 
   defp prune_consumers([], _state), do: :ok

--- a/test/fault_tolerance_test.exs
+++ b/test/fault_tolerance_test.exs
@@ -1,0 +1,85 @@
+defmodule OffBroadwayRedisStream.FaultToleranceTest do
+  use ExUnit.Case
+
+  alias OffBroadwayRedisStream.{Heartbeat, Producer, RedixClient}
+
+  @redis_opts [
+    host: "bad-host-name",
+    port: 9123,
+    sync_connect: false,
+    exit_on_disconnection: false
+  ]
+
+  @opts [
+    redis_client_opts: @redis_opts,
+    stream: "test",
+    make_stream: true,
+    group: "test-group",
+    consumer_name: "test-consumer"
+  ]
+
+  defmodule DummyProducer do
+    use Broadway
+
+    def start_link(opts) do
+      Broadway.start_link(__MODULE__,
+        name: __MODULE__,
+        producer: [
+          module: {Producer, opts}
+        ],
+        processors: [
+          default: [min_demand: 5, max_demand: 1000]
+        ]
+      )
+    end
+
+    def handle_message(_, message, _) do
+      message
+    end
+  end
+
+  test "producer starts with unreachable redis" do
+    assert {:ok, pid} = DummyProducer.start_link(@opts)
+
+    stop_process(pid)
+  end
+
+  test "producer does not kill supervisor" do
+    children = [
+      {DummyProducer, @opts}
+    ]
+
+    opts = [strategy: :one_for_one]
+    {:ok, pid} = Supervisor.start_link(children, opts)
+
+    Process.sleep(1000)
+    assert Process.alive?(pid)
+
+    stop_process(pid)
+  end
+
+  test "heartbeat does not kill supervisor with unreachable redis" do
+    assert {:ok, redis_config} = RedixClient.init(@opts)
+
+    children = [
+      {Heartbeat, client: RedixClient, config: redis_config, heartbeat_interval: 5_000}
+    ]
+
+    opts = [strategy: :one_for_one]
+    {:ok, pid} = Supervisor.start_link(children, opts)
+
+    Process.sleep(1000)
+    assert Process.alive?(pid)
+
+    stop_process(pid)
+  end
+
+  def stop_process(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :normal)
+
+    receive do
+      {:DOWN, ^ref, _, _, _} -> :ok
+    end
+  end
+end

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -6,6 +6,7 @@ defmodule OffBroadwayRedisStream.ProducerTest do
   alias OffBroadwayRedisStream.RedisMock
 
   import Mox
+  import TestHelper
 
   defmodule Forwarder do
     use Broadway
@@ -394,18 +395,4 @@ defmodule OffBroadwayRedisStream.ProducerTest do
     end
   end
 
-  defp redix_opts, do: [host: host(), port: port()]
-
-  defp host do
-    System.get_env("REDIS_HOST") || "localhost"
-  end
-
-  defp port do
-    if p = System.get_env("REDIS_PORT") do
-      {port, ""} = Integer.parse(p)
-      port
-    else
-      6379
-    end
-  end
 end

--- a/test/support/slow_redix_client.ex
+++ b/test/support/slow_redix_client.ex
@@ -1,0 +1,40 @@
+defmodule OffBroadwayRedisStream.SlowRedixClient do
+  @moduledoc false
+
+  @behaviour OffBroadwayRedisStream.RedisClient
+
+  alias OffBroadwayRedisStream.RedixClient
+
+  @impl true
+  defdelegate init(config), to: RedixClient
+
+  @impl true
+  defdelegate fetch(demand, last_id, config), to: RedixClient
+
+  @impl true
+  defdelegate consumers_info(config), to: RedixClient
+
+
+  @impl true
+  def create_group(id, config) do
+    Process.sleep(config[:heartbeat_sleep])
+    RedixClient.create_group(id, config)
+  end
+
+  @impl true
+  defdelegate pending(consumer, count, config), to: RedixClient
+
+  @impl true
+  defdelegate claim(idle, ids, config), to: RedixClient
+
+  @impl true
+  defdelegate ack(ids, config), to: RedixClient
+
+  @impl true
+  defdelegate delete_message(ids, config), to: RedixClient
+
+  @impl true
+  defdelegate delete_consumers(consumers, config), to: RedixClient
+end
+
+

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -1,0 +1,28 @@
+defmodule TestHelper do
+  def stop_process(pid) do
+    Process.flag(:trap_exit, true)
+
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+
+    receive do
+      {:DOWN, ^ref, _, _, _} -> :ok
+    end
+  end
+
+  def redix_opts, do: [host: host(), port: port()]
+
+  defp host do
+    System.get_env("REDIS_HOST") || "localhost"
+  end
+
+  defp port do
+    if p = System.get_env("REDIS_PORT") do
+      {port, ""} = Integer.parse(p)
+      port
+    else
+      6379
+    end
+  end
+
+end


### PR DESCRIPTION
Prior to these changes, if Redis is unavailable during startup of an Elixir application or if Redis becomes unavailable during running, some commands executed would crash the supervisor and thus crash the application. The following changes where made:

 - remove checking the Redis version. Assume Redis is setup correctly.
 - move group creation into heartbeat. Use similar looping as heartbeat check but call it before heartbeat in handle_continue.