### PR TITLE
Upgrade logging to use warning over warn

### DIFF
--- a/lib/heartbeat.ex
+++ b/lib/heartbeat.ex
@@ -47,7 +47,7 @@ defmodule OffBroadwayRedisStream.Heartbeat do
         :ok
 
       {:error, %RedisClient.ConnectionError{} = error} when retry_count < @max_retries ->
-        Logger.warn(
+        Logger.warning(
           "Failed to create group, retry_count: #{retry_count}, reason: #{inspect(error.reason)}"
         )
 
@@ -69,7 +69,7 @@ defmodule OffBroadwayRedisStream.Heartbeat do
         Process.send_after(self(), :heartbeat, interval)
 
       {:error, %RedisClient.ConnectionError{} = error} when retry_count < @max_retries ->
-        Logger.warn(
+        Logger.warning(
           "Failed to send heartbeat, retry_count: #{retry_count}, reason: #{inspect(error.reason)}"
         )
 

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -153,7 +153,7 @@ defmodule OffBroadwayRedisStream.Producer do
         {:noreply, [], %{state | pending_ack: []}}
 
       {:error, error} ->
-        Logger.warn(
+        Logger.warning(
           "Unable to acknowledge and delete messages with Redis. Reason: #{inspect(error)}"
         )
 
@@ -175,7 +175,7 @@ defmodule OffBroadwayRedisStream.Producer do
         {:noreply, [], %{state | pending_ack: []}}
 
       {:error, error} ->
-        Logger.warn("Unable to acknowledge messages with Redis. Reason: #{inspect(error)}")
+        Logger.warning("Unable to acknowledge messages with Redis. Reason: #{inspect(error)}")
 
         if length(ids) > state.max_pending_ack do
           {:stop, "Pending ack count is more than maximum limit #{state.max_pending_ack}", state}
@@ -197,7 +197,7 @@ defmodule OffBroadwayRedisStream.Producer do
         :ok
 
       {:error, error} ->
-        Logger.warn(
+        Logger.warning(
           "Unable to acknowledge and delete messages with Redis. Reason: #{inspect(error)}"
         )
     end
@@ -213,7 +213,7 @@ defmodule OffBroadwayRedisStream.Producer do
         :ok
 
       {:error, error} ->
-        Logger.warn("Unable to acknowledge messages with Redis. Reason: #{inspect(error)}")
+        Logger.warning("Unable to acknowledge messages with Redis. Reason: #{inspect(error)}")
     end
 
     Heartbeat.stop(state.heartbeat_pid)
@@ -463,7 +463,7 @@ defmodule OffBroadwayRedisStream.Producer do
 
     case apply(client, func, args ++ [redis_config]) do
       {:error, %RedisClient.ConnectionError{} = error} when retry_count < max_retries ->
-        Logger.warn(
+        Logger.warning(
           "Failed to run #{func}, retry_count: #{retry_count}, reason: #{inspect(error.reason)}"
         )
 


### PR DESCRIPTION
Eliminates compiler warnings around use of the deprecated Logger.warn, such as:

  warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead
      lib/heartbeat.ex:72: OffBroadwayRedisStream.Heartbeat.heartbeat/2